### PR TITLE
Allow console to execute shop command for the player.

### DIFF
--- a/src/main/java/com/pokeskies/skiesskins/commands/AliasCommands.kt
+++ b/src/main/java/com/pokeskies/skiesskins/commands/AliasCommands.kt
@@ -17,17 +17,9 @@ class AliasCommands {
                 for (command in shop.options.aliases) {
                     dispatcher.register(
                         Commands.literal(command)
-                            .requires { obj: CommandSourceStack -> obj.isPlayer }
                             .requires(Permissions.require("skiesskins.open.$shopId"))
                             .executes { ctx ->
-                                val player = ctx.source.player
-                                if (player == null) {
-                                    ctx.source.sendMessage(
-                                        Component.text("Must be a player to run this command!")
-                                            .color(NamedTextColor.RED)
-                                    )
-                                    return@executes 1
-                                }
+                                val player = ctx.source.playerOrException
                                 if (!Permissions.check(player, "skiesskins.open.$shopId")) {
                                     ctx.source.sendMessage(
                                         Component.text("You don't have permission to run this command!")

--- a/src/main/java/com/pokeskies/skiesskins/commands/subcommands/ShopCommand.kt
+++ b/src/main/java/com/pokeskies/skiesskins/commands/subcommands/ShopCommand.kt
@@ -32,7 +32,6 @@ class ShopCommand : SubCommand {
                         openShop(ctx, shopId, players)
                     }
                 )
-                .requires { obj: CommandSourceStack -> obj.isPlayer }
                 .executes { ctx ->
                     val shopId = StringArgumentType.getString(ctx, "shop")
                     openShop(ctx, shopId, listOf(ctx.source.playerOrException))


### PR DESCRIPTION
## Description
- Using `/skiesskins shop <shop> <player>` through console results in an invalid argument due to the command requiring a Player before it can be executed, this has the unfortunate side effect of also blocking the command through `/execute as`, which runs a command through the user from a different source.
## Implementation
- To avoid this issue, instead of blocking the execution without a Player, we can copy the format of the other commands and rely on `context.source.playerOrException` to handle the Player (or lack of a Player). With this, the console can run `/skiesskins shop <shop> <player>` and also `/execute as <player> run skiesskins shop <shop>`.
  - This is already the format for the other commands, such as `/skiesskins remover <player>`.